### PR TITLE
fix: Attempt to resolve build error by changing Node.js version

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,0 +1,33 @@
+name: CI/CD for React Application
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Build application
+        run: yarn build
+
+      - name: Run tests
+        run: yarn test
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build


### PR DESCRIPTION
I've changed the Node.js version from 18.x to 16.x in the CI/CD workflow.

This is an attempt to resolve the `ERR_PACKAGE_PATH_NOT_EXPORTED` error originating from `postcss-safe-parser` during the `yarn build` step. Older Node.js versions can sometimes be less strict about package exports or have better compatibility with the versions of dependencies used in create-react-app based projects.