### PR TITLE
fix: Resolve ESLint errors and browserslist warning in CI

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
+      - name: Update Browserslist DB
+        run: npx browserslist@latest --update-db
+
       - name: Build application
         run: yarn build
 

--- a/src/CriteriaTable.js
+++ b/src/CriteriaTable.js
@@ -9,7 +9,7 @@ import Button from '@material-ui/core/Button';
 import {useTranslation} from 'react-i18next';
 
 export default function CriteriaTable(props) {
-    const { t, i18n} = useTranslation();
+    const { t } = useTranslation();
 
     const data_columns = [
         {name: t('DATA_COLUMN_CRITERION'), attribute:'criterionName'},

--- a/src/Form.js
+++ b/src/Form.js
@@ -31,7 +31,7 @@ export default function Form(props) {
 
     const styles  = useStyles();
     const [state, setState] = useState(initState);
-    const { t, i18n } = useTranslation();
+    const { t } = useTranslation();
 
 
     const handleChange = (event) => {

--- a/src/GridForm.js
+++ b/src/GridForm.js
@@ -42,7 +42,7 @@ export default function GridForm(props) {
 
     const styles  = useStyles();
     const [state, setState] = useState(initState);
-    const  {t, i18n} = useTranslation();
+    const  {t} = useTranslation();
 
     const handleChange = (event) => {
         const { name, value } = event.target;

--- a/src/LinearStepper.js
+++ b/src/LinearStepper.js
@@ -10,7 +10,7 @@ import Grid from "./Grid";
 import GridForm from "./GridForm";
 import ResultGrid from './ResultGrid';
 import { useTranslation,  } from 'react-i18next';
-import { useState, Suspense } from "react";
+import { useState } from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import XLSX from 'xlsx';
 import {criteriaToDataColumns} from './helpers';
@@ -32,7 +32,7 @@ const useStyles = makeStyles((theme) => ({
 
 export default function LinearStepper(props) {
   const classes = useStyles();
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const dataColumnName = t('DATA_COLUMN_NAME');
   const [state, setState] = useState({
     criteria: [],
@@ -292,7 +292,7 @@ export default function LinearStepper(props) {
               variant="contained"
               color="primary"
               onClick={handleNext}
-              disabled={(activeStep == 0 && state.disableGrid )|| (activeStep == 1 && state.disableResults)}
+              disabled={(activeStep === 0 && state.disableGrid )|| (activeStep === 1 && state.disableResults)}
               className={classes.button}
             >
               {activeStep === steps.length - 1 ? t('BUTTON_FINISH') : t('BUTTON_NEXT')}

--- a/src/ResultGrid.js
+++ b/src/ResultGrid.js
@@ -5,7 +5,7 @@ import topsis_predict from "./topsis";
 
 
 export default function ResultGrid(props) {
-    const {t, i18n} = useTranslation();
+    const {t} = useTranslation();
     
     const columns = [
         {field:'ranking', headerName: '#', type:"number", width: 60},


### PR DESCRIPTION
This commit addresses issues identified in the CI build process:

1.  **Update Browserslist Database:**
    - I added a step `npx browserslist@latest --update-db` to the `.github/workflows/cicd.yml` before the build step. This resolves the "caniuse-lite is outdated" warning.

2.  **Fix ESLint `no-unused-vars` errors:**
    - I removed unused `i18n` imports/variables from: - `src/CriteriaTable.js` - `src/Form.js` - `src/GridForm.js` - `src/LinearStepper.js` - `src/ResultGrid.js`
    - I removed unused `Suspense` import from `src/LinearStepper.js`.
    - In all cases where `i18n` was destructured from `useTranslation()`, I removed it if not used (e.g., `const {t, i18n}` became `const {t}`).

3.  **Fix ESLint `eqeqeq` errors:**
    - In `src/LinearStepper.js` (line 295), I changed loose equality operators (`==`) to strict equality operators (`===`) to resolve two `eqeqeq` errors.

These changes should allow the CI build to pass without ESLint errors or warnings being treated as errors.